### PR TITLE
Fix NoneType crash in test_gapfill_database when media is None

### DIFF
--- a/modelseedpy/core/msgapfill.py
+++ b/modelseedpy/core/msgapfill.py
@@ -132,19 +132,20 @@ class MSGapfill:
             return True
         if self.gfpkgmgr.getpkg("GapfillingPkg").test_solution.status == 'infeasible':
             return False
+        media_id = media.id if media else "Complete"
         gf_sensitivity = {}
         if target != "rxn00062_c0":
             gf_sensitivity = self.mdlutl.get_attributes("gf_sensitivity", {})
-        if media.id not in gf_sensitivity:
-            gf_sensitivity[media.id] = {}
-        if target not in gf_sensitivity[media.id]:
-            gf_sensitivity[media.id][target] = {}
+        if media_id not in gf_sensitivity:
+            gf_sensitivity[media_id] = {}
+        if target not in gf_sensitivity[media_id]:
+            gf_sensitivity[media_id][target] = {}
         filter_msg = " "
         note = "FAF"
         if before_filtering:
             filter_msg = " before filtering "
             note = "FBF"
-        gf_sensitivity[media.id][target][
+        gf_sensitivity[media_id][target][
             note
         ] = self.mdlutl.find_unproducible_biomass_compounds(target)
         if target != "rxn00062_c0":
@@ -153,7 +154,7 @@ class MSGapfill:
             "No gapfilling solution found"
             + filter_msg
             + "for "
-            + media.id
+            + media_id
             + " activating "
             + target
         )


### PR DESCRIPTION
## Summary

- `MSGapfill.test_gapfill_database()` crashes with `AttributeError: 'NoneType' object has no attribute 'id'` when `media=None` (Complete media) and gapfilling fails to find a solution
- The error path (lines 138-156) accesses `media.id` without a None check to record gf_sensitivity and log a warning
- Fix: extract `media.id` into a local `media_id` variable with fallback to `"Complete"` before using it

## Reproduction

```python
from modelseedpy import MSGapfill

gapfiller = MSGapfill(model, default_target="bio1", default_gapfill_templates=[template])
# Crashes when no solution is found and media is None:
solution = gapfiller.run_gapfilling(media=None)
# -> AttributeError: 'NoneType' object has no attribute 'id'
```

## Context

Found this while building the new ModelSEED REST API. When users run gapfilling with Complete media (no media restriction, `media=None`), and the solver can't find a solution, the error/sensitivity recording path crashes instead of returning `None` gracefully.

We have a workaround in the API (passing `MSMedia("Complete", "Complete")` instead of `None`), but the upstream fix is a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)