### PR TITLE
Fix drain_list loading: create DM_ demand reactions during model build

### DIFF
--- a/modelseedpy/core/msbuilder.py
+++ b/modelseedpy/core/msbuilder.py
@@ -360,9 +360,9 @@ class MSBuilder:
             return None
         if self.template.drains:
             demands = {
-                x.id: t[0]
+                x.id: -1000
                 for x, t in self.template.drains.items()
-                if t[0] < 0 and x.id in self.template_species_to_model_species
+                if x.id in self.template_species_to_model_species
             }
             return [self.build_demand_reaction(x, v) for x, v in demands.items()]
         else:

--- a/modelseedpy/core/mstemplate.py
+++ b/modelseedpy/core/mstemplate.py
@@ -1602,6 +1602,7 @@ class MSTemplateBuilder:
         builder.reactions = d["reactions"]
         builder.biochemistry_ref = d["biochemistry_ref"]
         builder.biomasses = d["biomasses"]
+        builder.drains = d.get("drain_list", {})
 
         return builder
 


### PR DESCRIPTION
## Summary

- `MSTemplateBuilder.from_dict()` was silently dropping the `drain_list` from template JSON files, so `template.drains` stayed empty
- `MSBuilder.build_drains()` fell back to `DEFAULT_SINKS` and only created SK_ (sink) reactions, never DM_ (demand) reactions
- Without `DM_cpd11416_c0`, cobrapy FBA returns 0 growth because `cpd11416` (Biomass) produced by `bio1` has no outlet

## Changes

1. **`mstemplate.py`**: `from_dict()` now reads `drain_list` into `builder.drains`
2. **`msbuilder.py`**: `build_demands()` creates DM_ reactions for all drain compounds (previously required `lower_bound < 0`, but template drain_list entries use `[0, 1000]`)

## Context

Found while building the modelseed-api REST backend. When loading templates from local JSON files via `MSTemplateBuilder.from_dict()` (instead of KBase workspace), models built with `MSBuilder.build()` had SK_ reactions but no DM_ reactions. The gapfiller adds DM_ to its internal clone, but they don't persist to the final model unless the LP solver includes them in the solution.

In KBase, templates loaded via the workspace object factory (`kbase_api.get_from_ws()`) may handle drain_list differently, which is why this wasn't caught before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)