### PR TITLE
Drop unused msexpression import from proteomefittingpkg

### DIFF
--- a/modelseedpy/fbapkg/proteomefittingpkg.py
+++ b/modelseedpy/fbapkg/proteomefittingpkg.py
@@ -7,7 +7,6 @@ import math
 from optlang.symbolics import Zero, add
 from modelseedpy.fbapkg.basefbapkg import BaseFBAPkg
 from modelseedpy.core.fbahelper import FBAHelper
-from modelseedpy.multiomics.msexpression import MSExpression
 
 # Options for default behavior
 LOWEST = 10


### PR DESCRIPTION
## Summary

`MSExpression` is imported in `modelseedpy/fbapkg/proteomefittingpkg.py` but never referenced anywhere in the module (the code uses string literals such as `"genome"` and `"column_norm"` instead of module constants).

Beyond being dead code, the import couples every transitive import of `modelseedpy.fbapkg` to `modelseedpy.multiomics.msexpression` — which pulls in pandas, numpy, and `msmodelutl` at import time. In my fork, this exact coupling rotted into an import-time crash for all `fbapkg` consumers (including `mscommunity`) when the module-level names in `msexpression` changed. Removing the unused import eliminates that failure mode here.

No functional change: the removed name is unused, so behavior is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G