### PR TITLE
Minimal media: nan-safe growth guard and fix undefined display() call

### DIFF
--- a/modelseedpy/core/msminimalmedia.py
+++ b/modelseedpy/core/msminimalmedia.py
@@ -85,7 +85,7 @@ def bioFlux_check(model, sol=None, sol_dict=None, min_growth=0.1):
             f" where the observed growth value was {simulated_growth}."
         )
     if sol.status != "optimal":
-        display(sol)
+        print(sol)
     return sol_dict
 
 
@@ -128,9 +128,12 @@ class MSMinimalMedia:
         org_model, min_growth=None, environment=None, interacting=True, printing=True
     ):
         """minimize the total in-flux of exchange reactions in the model"""
-        if org_model.slim_optimize() == 0:
+        # nan-safe guard: an infeasible model returns nan from slim_optimize,
+        # and nan == 0 is False, so the old check let infeasible models through
+        growth = org_model.slim_optimize()
+        if growth != growth or growth <= 1e-8:
             raise ObjectiveError(
-                f"The model {org_model.id} possesses an objective value of 0 in complete media, "
+                f"The model {org_model.id} possesses an objective value of {growth} in complete media, "
                 "which is incompatible with minimal media computations."
             )
         model_util = MSModelUtil(org_model, True)


### PR DESCRIPTION
## Summary

Two self-contained defects in `modelseedpy/core/msminimalmedia.py`:

1. **nan-unsafe zero-growth guard.** `minimize_flux` guarded with `org_model.slim_optimize() == 0`, but an infeasible model returns `nan`, and `nan == 0` is `False` — so infeasible models slipped past the guard and failed later with an opaque error. The guard now catches `nan` and near-zero values (`growth != growth or growth <= 1e-8`) and reports the observed objective value in the `ObjectiveError` message.

2. **Undefined `display(sol)`.** `bioFlux_check` called `display(sol)` on non-optimal solutions, which is a `NameError` in module scope outside IPython — masking the actual solver status exactly when it needed to be reported. Replaced with `print(sol)`.

Both were found while diagnosing a media-sweep score-coverage collapse downstream; these are the pieces that apply cleanly to this tree.

## Note for the maintainer

While porting this I noticed `minimize_flux` (and siblings) call an `MSModelUtil` API that doesn't exist in this tree's `modelseedpy/core/msmodelutl.py` — e.g. `MSModelUtil(org_model, True)` (the constructor here takes only `model`), `model_util.add_medium(...)`, `model_util.add_minimal_objective_cons(...)`, `model_util.add_objective(...)`. As-is these paths raise `TypeError`/`AttributeError` when invoked. I have further fixes for environment-application order, caller-model mutation, and a per-call memory leak in media sweeps, but they depend on that diverged `MSModelUtil` API, so they'll come separately once the API question is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G