### PR TITLE
Document the pkgmgrs release contract (memory-leak/OOM hazard)

### DIFF
--- a/modelseedpy/fbapkg/mspackagemanager.py
+++ b/modelseedpy/fbapkg/mspackagemanager.py
@@ -12,6 +12,13 @@ class MSPackageManager:
     Class for organizing FBA package objects
     """
 
+    # NOTE: entries pin their key (a cobra model, often a full per-call copy)
+    # for the process lifetime, and weak keying cannot help because each value
+    # strongly references its key (self.model, attached packages). Code that
+    # wraps throwaway model copies MUST release its entry when done:
+    #     MSPackageManager.pkgmgrs.pop(model, None)
+    # — otherwise sweeps that wrap a copy per call leak one model copy per
+    # call, and large multi-worker runs die by OOM.
     pkgmgrs = {}
 
     @staticmethod


### PR DESCRIPTION
## Summary

Documentation-only change to `modelseedpy/fbapkg/mspackagemanager.py`.

`MSPackageManager.pkgmgrs` pins every model ever wrapped for the process lifetime — `MSModelUtil.__init__` registers each model here via `get_pkg_mgr(model)`. Weak keying can't fix this, because each `MSPackageManager` value strongly references its key through `self.model` and its attached packages.

For long-lived models that's harmless, but any code that wraps a throwaway per-call model copy leaks one full copy per call unless it pops its entry when done (`MSPackageManager.pkgmgrs.pop(model, None)`). Downstream, exactly this pattern in minimal-media sweeps leaked ~4 model copies per medium per worker, and a 62-worker run was OOM-killed on a 188 GB machine before the leak was traced here.

This PR adds a NOTE at the dict definition stating the release contract, so future per-call wrappers know to clean up. No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G