### PR TITLE
Sync core/__init__.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/core/__init__.py
+++ b/modelseedpy/core/__init__.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+# Import exceptions first to avoid circular import issues
+from modelseedpy.core.exceptions import *
+
 from modelseedpy.core.rast_client import RastClient
 from modelseedpy.core.msgenome import MSGenome
 from modelseedpy.core.fbahelper import FBAHelper
@@ -11,7 +14,8 @@ from modelseedpy.core.msgapfill import MSGapfill
 from modelseedpy.core.msatpcorrection import MSATPCorrection
 from modelseedpy.core.msgrowthphenotypes import MSGrowthPhenotypes, MSGrowthPhenotype
 from modelseedpy.core.msmodelutl import MSModelUtil
+from modelseedpy.core.msminimalmedia import MSMinimalMedia, minimizeFlux_withGrowth, bioFlux_check
 from modelseedpy.core.mstemplate import MSTemplateBuilder
 from modelseedpy.core.msmodelreport import MSModelReport
 from modelseedpy.core.annotationontology import AnnotationOntology
-from modelseedpy.core.exceptions import *
+from modelseedpy.core.report import *


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/core/__init__.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

**Note:** this `__init__` reflects the fork's module set for `modelseedpy.core` — e.g. `from modelseedpy.core.report import *` (`report.py` is added in a sibling PR of this series). Merge the sibling module PRs before or with this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
