### PR TITLE
Sync core/exceptions.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/core/exceptions.py
+++ b/modelseedpy/core/exceptions.py
@@ -14,47 +14,34 @@ class FeasibilityError(Exception):
         super(FeasibilityError, self).__init__(message)
 
 
-class PackageError(Exception):
-    """Error in package manager"""
-
-    pass
-
+# PackageError is defined in mspackagemanager to avoid circular imports
+# Import it here for backwards compatibility
+from modelseedpy.fbapkg.mspackagemanager import PackageError
 
 class GapfillingError(Exception):
     """Error in model gapfilling"""
+    pass
 
+class ParameterError(Exception):
+    """Error in a parameterization"""
+    pass 
+
+class ObjectAlreadyDefinedError(Exception):
+    pass
+
+class NoFluxError(Exception):
+    """Error for FBA solutions"""
+    pass
+
+class ObjectiveError(Exception):
+    """Erroneous assignment of a secondary objective via a constraint"""
+    pass
+
+class ModelError(Exception):
+    """Errors in a model that corrupt the simulation"""
     pass
 
 
 class ObjectError(Exception):
     """Error in the construction of a base KBase object"""
-
-    pass
-
-
-class ParameterError(Exception):
-    """Error in a parameterization"""
-
-    pass
-
-
-class ObjectAlreadyDefinedError(Exception):
-    pass
-
-
-class NoFluxError(Exception):
-    """Error for FBA solutions"""
-
-    pass
-
-
-class ObjectiveError(Exception):
-    """Erroneous assignment of a secondary objective via a constraint"""
-
-    pass
-
-
-class ModelError(Exception):
-    """Errors in a model that corrupt the simulation"""
-
     pass


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/core/exceptions.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
