### PR TITLE
Sync core/rpcclient.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/core/rpcclient.py
+++ b/modelseedpy/core/rpcclient.py
@@ -72,19 +72,7 @@ class RPCClient:
             if ret.headers.get("content-type") == "application/json":
                 err = ret.json()
                 if "error" in err:
-                    error_body = err["error"]
-                    # JSON-RPC servers should return an object here, but
-                    # tutorial.theseed.org and some other backends
-                    # occasionally return a plain string or a list under
-                    # load. `ServerError(**error_body)` explodes with
-                    # `TypeError: argument after ** must be a mapping,
-                    # not str`, masking the real upstream failure. Coerce
-                    # non-dict shapes into the same ServerError we'd
-                    # produce for a non-JSON 500.
-                    if isinstance(error_body, dict):
-                        raise ServerError(**error_body)
-                    else:
-                        raise ServerError("Unknown", 0, str(error_body))
+                    raise ServerError(**err["error"])
                 else:
                     raise ServerError("Unknown", 0, ret.text)
             else:


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/core/rpcclient.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
