### PR TITLE
Sync fbapkg/__init__.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/fbapkg/__init__.py
+++ b/modelseedpy/fbapkg/__init__.py
@@ -6,6 +6,7 @@ from modelseedpy.fbapkg.basefbapkg import BaseFBAPkg
 from modelseedpy.fbapkg.revbinpkg import RevBinPkg
 from modelseedpy.fbapkg.reactionusepkg import ReactionUsePkg
 from modelseedpy.fbapkg.simplethermopkg import SimpleThermoPkg
+from modelseedpy.fbapkg.commkineticpkg import CommKineticPkg
 from modelseedpy.fbapkg.totalfluxpkg import TotalFluxPkg
 from modelseedpy.fbapkg.bilevelpkg import BilevelPkg
 from modelseedpy.fbapkg.kbasemediapkg import KBaseMediaPkg


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/fbapkg/__init__.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

**Note:** imports `CommKineticPkg` from `fbapkg/commkineticpkg.py`, which is added in a sibling PR of this series — merge that one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
