### PR TITLE
Sync fbapkg/bilevelpkg.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/fbapkg/bilevelpkg.py
+++ b/modelseedpy/fbapkg/bilevelpkg.py
@@ -11,6 +11,7 @@ from cobra.core import (
     Reaction,
 )  # !!! None of these imports are used
 from modelseedpy.fbapkg.basefbapkg import BaseFBAPkg
+import re
 
 # Base class for FBA packages
 class BilevelPkg(BaseFBAPkg):
@@ -76,7 +77,7 @@ class BilevelPkg(BaseFBAPkg):
                         coefficients[var_name][var] = item["args"][0]["value"]
         for var in variables:
             if var.type == "continuous":
-                dvar = self.build_variable("duallb", var, obj_coef)
+                dvar = self.build_variable("duallb", var, obj_coef)   #!!! why is this repeated twice?
                 if dvar != None:
                     if var not in coefficients:
                         coefficients[var] = {}


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/fbapkg/bilevelpkg.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
