### PR TITLE
Sync fbapkg/drainfluxpkg.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/fbapkg/drainfluxpkg.py
+++ b/modelseedpy/fbapkg/drainfluxpkg.py
@@ -3,18 +3,17 @@
 from __future__ import absolute_import
 
 import logging
-from optlang.symbolics import Zero, add
-from modelseedpy.fbapkg.basefbapkg import BaseFBAPkg
-
 logger = logging.getLogger("modelseedpy")
 
-# Base class for FBA packages
+from modelseedpy.fbapkg.basefbapkg import BaseFBAPkg
+from modelseedpy.core.fbahelper import FBAHelper
+
+#Base class for FBA packages
 class DrainFluxPkg(BaseFBAPkg):
     def __init__(self, model):
         BaseFBAPkg.__init__(self, model, "drain flux", {}, {"drain"})
-        self.update_drain_fluxes(self)
-
-    def build_package(self, parameters):
+        self.update_drain_fluxes()
+        
         self.validate_parameters(
             parameters,
             [],
@@ -28,7 +27,7 @@ class DrainFluxPkg(BaseFBAPkg):
             },
         )
         if self.parameters["update_drain_fluxes"]:
-            self.update_drain_fluxes(self)
+            self.update_drain_fluxes()
         if self.parameters["add_all_intracellular_drains"]:
             for cpd in self.model.metabolites:
                 self.add_drain_reaction(
@@ -38,8 +37,8 @@ class DrainFluxPkg(BaseFBAPkg):
                 )
         else:
             for cpd in self.parameters["drain_compounds"]:
-                if cpd in self.metabolites:
-                    cpdobj = self.metabolites.get_by_id(cpd)
+                if cpd in self.model.metabolites:
+                    cpdobj = self.model.metabolites.get_by_id(cpd)
                     self.add_drain_reaction(
                         cpdobj,
                         self.parameters["drain_compounds"][cpd]["uptake"],


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/fbapkg/drainfluxpkg.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
