### PR TITLE
Sync fbapkg/fullthermopkg.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/fbapkg/fullthermopkg.py
+++ b/modelseedpy/fbapkg/fullthermopkg.py
@@ -13,51 +13,21 @@ from modelseedpy.core.fbahelper import FBAHelper
 # Base class for FBA packages
 class FullThermoPkg(BaseFBAPkg):
     @staticmethod
-    def default_concentration():
+    def default_concentrations():
         return {
-            "cpd00067_c0": [0.0000001, 0.0000001],  # M H+ - equivalent to pHint = 7
-            "cpd00007_c0": [1e-07, 8.2e-06],  # M O2 instracellular
-            "cpd00011_c0": [1e-08, 0.0014],  # M CO2 instracellular
-            "cpd00067_e0": [
-                3.16228e-08,
-                3.16228e-07,
-            ],  # M H+ - equivalent to pHext = 6.5
-            "cpd00009_e0": [
-                0.056,
-                0.056,
-            ],  # Extracellular phosphate - overridden by media when media concentration is given
-            "cpd00048_e0": [
-                0.0030,
-                0.0030,
-            ],  # Extracellular sulfate - overridden by media when media concentration is given
-            "cpd00013_e0": [
-                0.019,
-                0.019,
-            ],  # Extracellular ammonia - overridden by media when media concentration is given
-            "cpd00971_e0": [
-                0.16,
-                0.16,
-            ],  # Extracellular sodium - overridden by media when media concentration is given
-            "cpd00205_e0": [
-                0.022,
-                0.022,
-            ],  # Extracellular potassium - overridden by media when media concentration is given
-            "cpd10515_e0": [
-                0.062,
-                0.062,
-            ],  # Extracellular Fe2+ - overridden by media when media concentration is given
-            "cpd00011_e0": [
-                0.00010,
-                0.00010,
-            ],  # Extracellular CO2 - overridden by media when media concentration is given
-            "cpd00007_e0": [
-                8.2e-06,
-                8.2e-06,
-            ],  # Extracellular O2 - overridden by media when media concentration is given
-            "cpd00027_e0": [
-                0.020,
-                0.020,
-            ],  # Extracellular glucose - overridden by media when media concentration is given
+            "cpd00067_c0":[0.0000001,0.0000001],      #M H+ - equivalent to pHint = 7
+            "cpd00007_c0":[1E-07,8.2E-06],            #M O2 instracellular
+            "cpd00011_c0":[1E-08,0.0014],             #M CO2 instracellular
+            "cpd00067_e0":[3.16228E-08,3.16228E-07],  #M H+ - equivalent to pHext = 6.5
+            "cpd00009_e0":[0.056,0.056],              #Extracellular phosphate - overridden by media when media concentration is given
+            "cpd00048_e0":[0.0030,0.0030],            #Extracellular sulfate - overridden by media when media concentration is given
+            "cpd00013_e0":[0.019,0.019],              #Extracellular ammonia - overridden by media when media concentration is given
+            "cpd00971_e0":[0.16,0.16],                #Extracellular sodium - overridden by media when media concentration is given
+            "cpd00205_e0":[0.022,0.022],              #Extracellular potassium - overridden by media when media concentration is given
+            "cpd10515_e0":[0.062,0.062],              #Extracellular Fe2+ - overridden by media when media concentration is given
+            "cpd00011_e0":[0.00010,0.00010],          #Extracellular CO2 - overridden by media when media concentration is given
+            "cpd00007_e0":[8.2E-06,8.2E-06],          #Extracellular O2 - overridden by media when media concentration is given
+            "cpd00027_e0":[0.020,0.020]               #Extracellular glucose - overridden by media when media concentration is given
         }
 
     def __init__(self, model):
@@ -70,7 +40,16 @@ class FullThermoPkg(BaseFBAPkg):
         )
         self.pkgmgr.addpkgs(["SimpleThermoPkg"])
 
-    def build_package(self, parameters, verbose=True):
+    def build_package(self,
+                      parameters: dict,      # simulation parameters
+                      verbose: bool = True
+                      ):
+        # define hard-coded defaults
+        self.parameters["deltaG_error"] = FullThermoPkg.default_deltaG_error()
+        self.parameters["compartment_potential"] = FullThermoPkg.default_compartment_potentials()
+        self.parameters["concentrations"] = FullThermoPkg.default_concentrations()
+
+        # amalgamate default and specified paramters 
         self.validate_parameters(
             parameters,
             [],
@@ -119,6 +98,7 @@ class FullThermoPkg(BaseFBAPkg):
                 if msid not in msid_hash:
                     msid_hash[msid] = {}
                 msid_hash[msid][metabolite.id] = metabolite
+            
             # Build concentration variable
             self.build_logconc_variable(metabolite)
             # Build error variable


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/fbapkg/fullthermopkg.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
