### PR TITLE
Sync fbapkg/objconstpkg.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/fbapkg/objconstpkg.py
+++ b/modelseedpy/fbapkg/objconstpkg.py
@@ -2,31 +2,17 @@
 
 from __future__ import absolute_import
 
-import logging
 from modelseedpy.fbapkg.basefbapkg import BaseFBAPkg
 
 # Base class for FBA packages
 class ObjConstPkg(BaseFBAPkg):
-    def __init__(self, model):
+    def __init__(self,model):
         BaseFBAPkg.__init__(self, model, "objective constraint", {}, {"objc": "none"})
-
-    def build_package(self, lower_bound, upper_bound):
-        return self.build_constraint(lower_bound, upper_bound)
-
-    def build_constraint(self, lower_bound, upper_bound):
+        
+    def build_package(self,lower_bound,upper_bound):
         coef = self.model.solver.objective.get_linear_coefficients(
             self.model.solver.objective.variables
         )
-        #Check if the constraint already exists and if so, just updating bounds in place
-        for name in self.constraints["objc"]:
-            constraint = self.constraints["objc"][name]
-            existing_coef = constraint.get_linear_coefficients(
-                constraint.variables
-            )
-            if coef == existing_coef:
-                constraint.lb = lower_bound
-                constraint.ub = upper_bound
-                return constraint
         return BaseFBAPkg.build_constraint(
             self, "objc", lower_bound, upper_bound, coef, None
         )


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/fbapkg/objconstpkg.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
