### PR TITLE
Sync fbapkg/problemreplicationpkg.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/fbapkg/problemreplicationpkg.py
+++ b/modelseedpy/fbapkg/problemreplicationpkg.py
@@ -2,12 +2,10 @@
 
 from __future__ import absolute_import
 
-import logging
-from optlang import Variable
-from optlang.symbolics import Zero, add
+
 from modelseedpy.fbapkg.basefbapkg import BaseFBAPkg
-from modelseedpy.fbapkg.revbinpkg import RevBinPkg
-from modelseedpy.fbapkg.totalfluxpkg import TotalFluxPkg
+from optlang import Variable
+import logging
 
 # Base class for FBA packages
 class ProblemReplicationPkg(BaseFBAPkg):
@@ -22,12 +20,12 @@ class ProblemReplicationPkg(BaseFBAPkg):
         shared_var_hash = {}
         for pkg in self.parameters["shared_variable_packages"]:
             fbapkg = self.modelutl.pkgmgr.getpkg(pkg)
-            for type in self.parameters["shared_variable_packages"][pkg]:
-                if type in fbapkg.variables:
-                    for objid in fbapkg.variables[type]:
+            for obj_type in self.parameters["shared_variable_packages"][pkg]:
+                if obj_type in pkg.variables:
+                    for objid in pkg.variables[obj_type]:
                         shared_var_hash[
-                            fbapkg.variables[type][objid].name
-                        ] = fbapkg.variables[type][objid]
+                            pkg.variables[obj_type][objid].name
+                        ] = pkg.variables[obj_type][objid]
         # Now copying over variables and constraints from other models and replacing shared variables
         count = 0
         for othermdl in self.parameters["models"]:


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/fbapkg/problemreplicationpkg.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
