### PR TITLE
Sync fbapkg/reactionusepkg.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/fbapkg/reactionusepkg.py
+++ b/modelseedpy/fbapkg/reactionusepkg.py
@@ -6,7 +6,6 @@ import logging
 logger = logging.getLogger(__name__)
 from optlang.symbolics import Zero, add  # !!! add is never used
 from modelseedpy.fbapkg.basefbapkg import BaseFBAPkg
-from modelseedpy.core.fbahelper import FBAHelper
 
 # Base class for FBA packages
 class ReactionUsePkg(BaseFBAPkg):
@@ -103,6 +102,8 @@ class ReactionUsePkg(BaseFBAPkg):
         return constraint
 
     def build_exclusion_constraint(self, flux_values=None):
+        # Deferred import to avoid circular dependency
+        from modelseedpy.core.fbahelper import FBAHelper
         flux_values = flux_values or FBAHelper.compute_flux_values_from_variables(
             self.model
         )


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/fbapkg/reactionusepkg.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
