### PR TITLE
Sync fbapkg/revbinpkg.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/fbapkg/revbinpkg.py
+++ b/modelseedpy/fbapkg/revbinpkg.py
@@ -23,18 +23,18 @@ class RevBinPkg(BaseFBAPkg):
                 self.build_variable(reaction)
                 self.build_constraint(reaction)
 
-    def build_variable(self, object):
-        return BaseFBAPkg.build_variable(self, "revbin", 0, 1, "binary", object)
+    def build_variable(self, rxn_obj):
+        return BaseFBAPkg.build_variable(self, "revbin", 0, 1, "binary", rxn_obj)
 
-    def build_constraint(self, object):
+    def build_constraint(self, rxn_obj):
         # -1000 * revbin(i) + forv(i) <= 0
         BaseFBAPkg.build_constraint(
             self,
             "revbinF",
             None,
             0,
-            {self.variables["revbin"][object.id]: -1000, object.forward_variable: 1},
-            object,
+            {self.variables["revbin"][rxn_obj.id]: -1000, rxn_obj.forward_variable: 1},
+            rxn_obj,
         )
         # 1000 * revbin(i) + revv(i) <= 1000
         return BaseFBAPkg.build_constraint(
@@ -42,6 +42,6 @@ class RevBinPkg(BaseFBAPkg):
             "revbinR",
             None,
             1000,
-            {self.variables["revbin"][object.id]: 1000, object.reverse_variable: 1},
-            object,
+            {self.variables["revbin"][rxn_obj.id]: 1000, rxn_obj.reverse_variable: 1},
+            rxn_obj,
         )


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/fbapkg/revbinpkg.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
