### PR TITLE
Sync fbapkg/simplethermopkg.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/fbapkg/simplethermopkg.py
+++ b/modelseedpy/fbapkg/simplethermopkg.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 import logging
 from modelseedpy.fbapkg.basefbapkg import BaseFBAPkg
 from optlang.symbolics import Zero
-import re
 
 # Base class for FBA packages
 class SimpleThermoPkg(BaseFBAPkg):
@@ -43,7 +42,7 @@ class SimpleThermoPkg(BaseFBAPkg):
             -1*self.parameters["max_potential"],
             self.parameters["max_potential"],
             "continuous",
-            object,
+            obj,
         )
     
     def build_dgp_variable(self, object):


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/fbapkg/simplethermopkg.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
