### PR TITLE
Sync fbapkg/totalfluxpkg.py from freiburgermsu fork

### DIFF
--- a/modelseedpy/fbapkg/totalfluxpkg.py
+++ b/modelseedpy/fbapkg/totalfluxpkg.py
@@ -8,12 +8,7 @@ from optlang.symbolics import Zero, add
 import json as _json
 from cobra.core import Gene, Metabolite, Model, Reaction
 from modelseedpy.fbapkg.basefbapkg import BaseFBAPkg
-
-# Adding a few exception classes to handle different types of errors
-class FeasibilityError(Exception):
-    """Error in FBA formulation"""
-
-    pass
+from modelseedpy.core.exceptions import FeasibilityError
 
 
 # Base class for FBA packages
@@ -34,9 +29,7 @@ class TotalFluxPkg(BaseFBAPkg):
                     )
                     self.model.add_cons_vars(self.variables["tf"][reaction.id])
                     self.constraints["tf"][reaction.id] = self.model.problem.Constraint(
-                        reaction.forward_variable
-                        + reaction.reverse_variable
-                        - self.variables["tf"][reaction.id],
+                        reaction.forward_variable + reaction.reverse_variable - self.variables["tf"][reaction.id],
                         lb=0,
                         ub=0,
                         name=reaction.id + "_tf",


### PR DESCRIPTION
## Summary

File-level sync of `modelseedpy/fbapkg/totalfluxpkg.py` to its state in freiburgermsu/ModelSEEDpy@971df5d (`main`), part of a file-by-file series reconciling the forks (together with #28–#31) so each module can be reviewed and merged independently.

The diff spans the forks' full divergence for this file since their last common ancestor: it can fold together many changes, and it can include reverts of changes made only on this repository's side. Please review it as a whole-file comparison rather than a curated patch.

**Series caveat:** several modules in this series reference siblings from the same series (package `__init__` imports, the `MSModelUtil` API surface). Merging a subset can leave imports or call sites temporarily inconsistent until the related file PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rcBA87xipNeaukuFW8N2G
